### PR TITLE
Fix crash when credentials fail to validate.

### DIFF
--- a/aws-mfa
+++ b/aws-mfa
@@ -137,6 +137,7 @@ def validate(args, config):
             logger.warn("Your existing credentials are missing or invalid, "
                         "obtaining new credentials.")
             get_credentials(short_term_name, key_id, access_key, args, config)
+            sys.exit()
 
         try:
             current_role = config.get(short_term_name, 'assumed_role_arn')


### PR DESCRIPTION
`get_credentials` is assumed to be the last function run, however execution
was continuing here. This caused a crash on line 180 because the expiration
key was not set.