### PR TITLE
Add ability to set MFA Device in credentials file.

### DIFF
--- a/aws-mfa
+++ b/aws-mfa
@@ -60,11 +60,6 @@ def main():
     if not os.path.isfile(AWS_CREDS_PATH):
         sys.exit('Could not locate credentials file at %s' % (AWS_CREDS_PATH,))
 
-    if not args.device:
-        if os.environ.get('MFA_DEVICE'):
-            args.device = os.environ.get('MFA_DEVICE')
-        else:
-            sys.exit('You must provide --device or MFA_DEVICE')
 
     if not args.duration:
         if os.environ.get('MFA_STS_DURATION'):
@@ -110,6 +105,14 @@ def validate(args, config):
         logger.error(e)
         sys.exit()
 
+    if not args.device:
+        if os.environ.get('MFA_DEVICE'):
+            args.device = os.environ.get('MFA_DEVICE')
+        elif config.has_option(long_term_name, 'aws_mfa_device'):
+            args.device = config.get(long_term_name, 'aws_mfa_device')
+        else:
+            sys.exit('You must provide --device or MFA_DEVICE or set "aws_mfa_device" in ".aws/credentials"')
+        
     # Validate presence of short-term section
     if not config.has_section(short_term_name):
         logger.info("Short term credentials section %s is missing, "


### PR DESCRIPTION
We work with multiple profiles a lot in awscli, so we wanted the ability to set the MFA device ARN per profile, in `.aws/credentials`.

Added checking for the option `aws_mfa_device` in the credentials file and setting that, if the command line arg isn't provided and the env var is unset.

Fails the same way if all three are absent.

I had to move the check for the env var and command line arg inside of validate in order to be able to check for all three in the same logic.
