### PR TITLE
Add doc about 'aws_mfa_device' in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 aws-mfa: Easily manage your AWS Security Credentials when using Multi-Factor Authentication (MFA)
 =================================================================================================
 
-**aws-mfa** makes it easy to manage your AWS SDK Security Credentials when Multi-Factor Authentication (MFA) is enforced on your AWS account. It automates the process of obtaining temporary credentials from the `AWS Security Token Service 
+**aws-mfa** makes it easy to manage your AWS SDK Security Credentials when Multi-Factor Authentication (MFA) is enforced on your AWS account. It automates the process of obtaining temporary credentials from the `AWS Security Token Service
 <http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html>`_ and updating your `AWS Credentials <https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs>`_ file (located at ``~/.aws/credentials``). Traditional methods of managing MFA-based credentials requires users to write their own bespoke scripts/wrappers to fetch temporary credentials from STS and often times manually update their AWS credentials file.
 
 The concept behind **aws-mfa** is that there are 2 types of credentials:
@@ -34,7 +34,7 @@ Option 2
 Credentials File Setup
 ----------------------
 
-In a typical AWS credentials file (located at ``~/.aws/credentials``), credentials are stored in sections, denoted by a pair of brackets: ``[]``. The ``[default]`` section stores your default credentials. You can store multiple sets of credentials using different profile names. If no profile is specified, the ``[default]`` section is always used. 
+In a typical AWS credentials file (located at ``~/.aws/credentials``), credentials are stored in sections, denoted by a pair of brackets: ``[]``. The ``[default]`` section stores your default credentials. You can store multiple sets of credentials using different profile names. If no profile is specified, the ``[default]`` section is always used.
 
 Long term credential sections are identified by the convention ``[<profile_name>-long-term]``. Short term credentials are identified by the typical convention: ``[<profile_name>]``. The following illustrates how you would configure you credentials file using **aws-mfa** with your default credentials:
 
@@ -78,7 +78,7 @@ After running `aws-mfa`, your credentials file would read:
     aws_access_key_id = YOUR_LONGTERM_KEY_ID
     aws_secret_access_key = YOUR_LONGTERM_ACCESS_KEY
 
-    [development] 
+    [development]
     aws_access_key_id = <POPULATED_BY_AWS-MFA>
     aws_secret_access_key = <POPULATED_BY_AWS-MFA>
     aws_security_token = <POPULATED_BY_AWS-MFA>
@@ -91,7 +91,8 @@ Usage
 
     --device arn:aws:iam::123456788990:mfa/dudeman
                             The MFA Device ARN. This value can also be provided
-                            via the environment variable 'MFA_DEVICE'.
+                            via the environment variable 'MFA_DEVICE' or the
+                            variable 'aws_mfa_device' in ~/.aws/credentials.
     --duration DURATION     The duration, in seconds, indicating how long the
                             temporary credentials should be valid. The minimum is
                             900 seconds (15 minutes) and the maximum is 3600
@@ -107,7 +108,7 @@ Usage
                             Friendly session name required when using --assume-
                             role
 
-**Argument precedence**: Command line arguments take precedence over environment variables. 
+**Argument precedence**: Command line arguments take precedence over environment variables.
 
 Usage Example
 -------------

--- a/aws-mfa
+++ b/aws-mfa
@@ -32,7 +32,9 @@ def main():
                         required=False,
                         metavar='arn:aws:iam::123456788990:mfa/dudeman',
                         help="The MFA Device ARN. This value can also be "
-                        "provided via the environment variable 'MFA_DEVICE'")
+                        "provided via the environment variable 'MFA_DEVICE' "
+                        "or the variable 'aws_mfa_device' "
+                        "in ~/.aws/credentials.")
     parser.add_argument('--duration',
                         type=int,
                         help="The duration, in seconds, indicating how long "
@@ -270,6 +272,7 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
     logger.info(
         "Success! Your credentials will expire in %s seconds at: %s"
         % (args.duration, response['Credentials']['Expiration']))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
That information appears in the help on the command line but it's not in the documentation (README)