### PR TITLE
Set better defaults for duration (43200 or 3600 with --assume-role). + Fix a bug.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,8 @@ Usage
 
     --device arn:aws:iam::123456788990:mfa/dudeman
                             The MFA Device ARN. This value can also be provided
-                            via the environment variable 'MFA_DEVICE'.
+                            via the environment variable 'MFA_DEVICE' or the
+                            ~/.aws/credentials variable 'aws_mfa_device'.
     --duration DURATION     The duration, in seconds, that the temporary
                             credentials should remain valid. Minimum value: 900
                             (15 minutes). Maximum: 129600 (36 hours). Defaults to

--- a/README.rst
+++ b/README.rst
@@ -92,10 +92,11 @@ Usage
     --device arn:aws:iam::123456788990:mfa/dudeman
                             The MFA Device ARN. This value can also be provided
                             via the environment variable 'MFA_DEVICE'.
-    --duration DURATION     The duration, in seconds, indicating how long the
-                            temporary credentials should be valid. The minimum is
-                            900 seconds (15 minutes) and the maximum is 3600
-                            seconds (1 hour). This value can also be provided via
+    --duration DURATION     The duration, in seconds, that the temporary
+                            credentials should remain valid. Minimum value: 900
+                            (15 minutes). Maximum: 129600 (36 hours). Defaults to
+                            43200 (12 hours), or 3600 (one hour) when using
+                            '--assume-role'. This value can also be provided via
                             the environment variable 'MFA_STS_DURATION'.
     --profile PROFILE       If using profiles, specify the name here. The default
                             profile name is 'default'. The value can also be

--- a/aws-mfa
+++ b/aws-mfa
@@ -287,7 +287,7 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
     logger.info(
         "Success! Your credentials will expire in %s seconds at: %s"
         % (args.duration, response['Credentials']['Expiration']))
-
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/aws-mfa
+++ b/aws-mfa
@@ -30,7 +30,8 @@ def main():
                         required=False,
                         metavar='arn:aws:iam::123456788990:mfa/dudeman',
                         help="The MFA Device ARN. This value can also be "
-                        "provided via the environment variable 'MFA_DEVICE'")
+                        "provided via the environment variable 'MFA_DEVICE' or"
+                        " the ~/.aws/credentials variable 'aws_mfa_device'.")
     parser.add_argument('--duration',
                         type=int,
                         help="The duration, in seconds, that the temporary "

--- a/aws-mfa
+++ b/aws-mfa
@@ -11,7 +11,6 @@ import datetime
 import logging
 import os
 import sys
-
 import boto3
 
 logger = logging.getLogger('botomfa')
@@ -23,7 +22,6 @@ logger.addHandler(stdout_handler)
 logger.setLevel(logging.DEBUG)
 
 AWS_CREDS_PATH = '%s/.aws/credentials' % (os.path.expanduser('~'),)
-STS_DEFAULT = 900
 
 
 def main():
@@ -35,12 +33,13 @@ def main():
                         "provided via the environment variable 'MFA_DEVICE'")
     parser.add_argument('--duration',
                         type=int,
-                        help="The duration, in seconds, indicating how long "
-                        "the temporary credentials should be valid. The "
-                        "minimum is 900 seconds (15 minutes) and the maximum "
-                        "is 3600 seconds (1 hour). This value can also be "
-                        "provided via the environment variable "
-                        "'MFA_STS_DURATION'.")
+                        help="The duration, in seconds, that the temporary "
+                             "credentials should remain valid. Minimum value: "
+                             "900 (15 minutes). Maximum: 129600 (36 hours). "
+                             "Defaults to 43200 (12 hours), or 3600 (one "
+                             "hour) when using '--assume-role'. This value "
+                             "can also be provided via the environment "
+                             "variable 'MFA_STS_DURATION'. ")
     parser.add_argument('--profile',
                         help="If using profiles, specify the name here. The "
                         "default profile name is 'default'. The value can "
@@ -60,7 +59,8 @@ def main():
     args = parser.parse_args()
 
     if not os.path.isfile(AWS_CREDS_PATH):
-        sys.exit('Could not locate credentials file at %s' % (AWS_CREDS_PATH,))
+        log_error_and_exit('Could not locate credentials file at '
+                           '%s' % (AWS_CREDS_PATH,))
 
     config = configparser.RawConfigParser()
     config.read(AWS_CREDS_PATH)
@@ -90,34 +90,36 @@ def validate(args, config):
         key_id = config.get(long_term_name, 'aws_access_key_id')
         access_key = config.get(long_term_name, 'aws_secret_access_key')
     except NoSectionError:
-        logger.error(
+        log_error_and_exit(
             "Long term credentials session '[%s]' is missing. "
             "You must add this section to your credentials file "
             "along with your long term 'aws_access_key_id' and "
             "'aws_secret_access_key'" % (long_term_name,))
-        sys.exit()
     except NoOptionError as e:
-        logger.error(e)
-        sys.exit()
+        log_error_and_exit(e)
 
+    # get device from param, env var or config
     if not args.device:
         if os.environ.get('MFA_DEVICE'):
             args.device = os.environ.get('MFA_DEVICE')
         elif config.has_option(long_term_name, 'aws_mfa_device'):
             args.device = config.get(long_term_name, 'aws_mfa_device')
         else:
-            sys.exit('You must provide --device or MFA_DEVICE or set '
-                     '"aws_mfa_device" in ".aws/credentials"')
+            log_error_and_exit(
+                'You must provide --device or MFA_DEVICE or set '
+                '"aws_mfa_device" in ".aws/credentials"')
 
+    # get assume_role from param or env var
+    if not args.assume_role:
+        if os.environ.get('MFA_ASSUME_ROLE'):
+            args.assume_role = os.environ.get('MFA_ASSUME_ROLE')
+
+    # get duration from param, env var or set default
     if not args.duration:
         if os.environ.get('MFA_STS_DURATION'):
             args.duration = int(os.environ.get('MFA_STS_DURATION'))
         else:
-            args.duration = STS_DEFAULT
-
-    if not args.assume_role:
-        if os.environ.get('MFA_ASSUME_ROLE'):
-            args.assume_role = os.environ.get('MFA_ASSUME_ROLE')
+            args.duration = 3600 if args.assume_role else 43200
 
     # Validate presence of short-term section
     if not config.has_section(short_term_name):
@@ -199,6 +201,12 @@ def validate(args, config):
                     % (diff.total_seconds(), exp))
 
 
+def log_error_and_exit(message):
+    """Log an error message and exit with error"""
+    logger.error(message)
+    sys.exit(1)
+
+
 def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
     try:
         token_input = raw_input
@@ -216,10 +224,11 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
     )
 
     if args.assume_role:
+
         if args.role_session_name is None:
-            logger.error("You must specify a role session name "
-                         "via --role-session-name")
-            sys.exit()
+            log_error_and_exit("You must specify a role session name "
+                               "via --role-session-name")
+
         response = client.assume_role(
             RoleArn=args.assume_role,
             RoleSessionName=args.role_session_name,
@@ -227,6 +236,7 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
             SerialNumber=args.device,
             TokenCode=mfa_token
         )
+
         config.set(
             short_term_name,
             'assumed_role',
@@ -243,6 +253,7 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
             SerialNumber=args.device,
             TokenCode=mfa_token
         )
+
         config.set(
             short_term_name,
             'assumed_role',
@@ -276,6 +287,7 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
     logger.info(
         "Success! Your credentials will expire in %s seconds at: %s"
         % (args.duration, response['Credentials']['Expiration']))
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The STS_DEFAULT should be the same as AWS's value:
http://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html

Replace the help string for --duration by the AWS help  of
aws sts get-session-token for '--duration-seconds'

Update help for --device param