### PR TITLE
Allow specifying the log level.

### DIFF
--- a/aws-mfa
+++ b/aws-mfa
@@ -51,21 +51,20 @@ def main():
                         help="Friendly session name required when using "
                         "--assume-role",
                         required=False)
-    parser.add_argument('--quiet',
-                        action='store_true',
-                        help="Decrease output verbosity.",
-                        default=False,
-                        required=False)
+    parser.add_argument('--log-level',
+                        help="Set log level",
+                        choices=[
+                            'CRITICAL', 'ERROR', 'WARNING',
+                            'INFO', 'DEBUG', 'NOTSET'
+                        ],
+                        required=False,
+                        default='DEBUG')
     args = parser.parse_args()
 
     if not os.path.isfile(AWS_CREDS_PATH):
         sys.exit('Could not locate credentials file at %s' % (AWS_CREDS_PATH,))
 
-    if args.quiet:
-        level = logging.ERROR
-    else:
-        level = logging.DEBUG
-
+    level = getattr(logging, args.log_level)
     setup_logger(level)
 
     config = configparser.RawConfigParser()

--- a/aws-mfa
+++ b/aws-mfa
@@ -15,12 +15,6 @@ import sys
 import boto3
 
 logger = logging.getLogger('botomfa')
-stdout_handler = logging.StreamHandler(stream=sys.stdout)
-stdout_handler.setFormatter(
-    logging.Formatter('%(levelname)s - %(message)s'))
-stdout_handler.setLevel(logging.DEBUG)
-logger.addHandler(stdout_handler)
-logger.setLevel(logging.DEBUG)
 
 AWS_CREDS_PATH = '%s/.aws/credentials' % (os.path.expanduser('~'),)
 STS_DEFAULT = 900
@@ -57,10 +51,22 @@ def main():
                         help="Friendly session name required when using "
                         "--assume-role",
                         required=False)
+    parser.add_argument('--quiet',
+                        action='store_true',
+                        help="Decrease output verbosity.",
+                        default=False,
+                        required=False)
     args = parser.parse_args()
 
     if not os.path.isfile(AWS_CREDS_PATH):
         sys.exit('Could not locate credentials file at %s' % (AWS_CREDS_PATH,))
+
+    if args.quiet:
+        level = logging.ERROR
+    else:
+        level = logging.DEBUG
+
+    setup_logger(level)
 
     config = configparser.RawConfigParser()
     config.read(AWS_CREDS_PATH)
@@ -276,6 +282,15 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
     logger.info(
         "Success! Your credentials will expire in %s seconds at: %s"
         % (args.duration, response['Credentials']['Expiration']))
+
+
+def setup_logger(level=logging.DEBUG):
+    stdout_handler = logging.StreamHandler(stream=sys.stdout)
+    stdout_handler.setFormatter(
+        logging.Formatter('%(levelname)s - %(message)s'))
+    stdout_handler.setLevel(level)
+    logger.addHandler(stdout_handler)
+    logger.setLevel(level)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I use aws-mfa quite a bit with a decorator function in my Python apps. Unfortunately this means there is a lot of spam in the logging. :( ~So I added a quiet argument to set log level to ERROR.~ I've added --log-level as suggested (rather than --quiet).

Would be awesome if this was merged into the main repo. Not sure if it's that useful for most but it could be?

(Also, any idea when an updated package might be pushed to pypi? Currently my requirements.txt uses the git repo so it can use my previously merged changes. :))