### PR TITLE
[ADD] override naming convention with command line arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Credentials File Setup
 
 In a typical AWS credentials file (located at ``~/.aws/credentials``), credentials are stored in sections, denoted by a pair of brackets: ``[]``. The ``[default]`` section stores your default credentials. You can store multiple sets of credentials using different profile names. If no profile is specified, the ``[default]`` section is always used.
 
-Long term credential sections are identified by the convention ``[<profile_name>-long-term]``. Short term credentials are identified by the typical convention: ``[<profile_name>]``. The following illustrates how you would configure you credentials file using **aws-mfa** with your default credentials:
+By default long term credential sections are identified by the convention ``[<profile_name>-long-term]`` and short term credentials are identified by the typical convention: ``[<profile_name>]``. The following illustrates how you would configure you credentials file using **aws-mfa** with your default credentials:
 
 .. code-block:: ini
 
@@ -49,7 +49,7 @@ After running ``aws-mfa``, your credentials file would read:
 
 .. code-block:: ini
 
-    [defult-long-term]
+    [default-long-term]
     aws_access_key_id = YOUR_LONGTERM_KEY_ID
     aws_secret_access_key = YOUR_LONGTERM_ACCESS_KEY
 
@@ -58,7 +58,6 @@ After running ``aws-mfa``, your credentials file would read:
     aws_access_key_id = <POPULATED_BY_AWS-MFA>
     aws_secret_access_key = <POPULATED_BY_AWS-MFA>
     aws_security_token = <POPULATED_BY_AWS-MFA>
-
 
 Similarly, if you utilize a credentials profile named **development**, your credentials file would look like:
 
@@ -70,7 +69,7 @@ Similarly, if you utilize a credentials profile named **development**, your cred
 
 
 
-After running `aws-mfa`, your credentials file would read:
+After running ``aws-mfa``, your credentials file would read:
 
 .. code-block:: ini
 
@@ -83,6 +82,62 @@ After running `aws-mfa`, your credentials file would read:
     aws_secret_access_key = <POPULATED_BY_AWS-MFA>
     aws_security_token = <POPULATED_BY_AWS-MFA>
 
+The default naming convention for the credential section can be overriden by using the ``--long-term-suffix`` and
+``--short-term-suffix`` command line arguments. For example, in a multi account scenario you can have one AWS account
+that manages the IAM users for your organization and have other AWS accounts for development, staging and production
+environments.
+
+After running ``aws-mfa`` once for each environment with a different value for ``--short-term-suffix``, your credentials
+file would read:
+
+.. code-block:: ini
+
+    [myorganization-long-term]
+    aws_access_key_id = YOUR_LONGTERM_KEY_ID
+    aws_secret_access_key = YOUR_LONGTERM_ACCESS_KEY
+
+    [myorganization-development]
+    aws_access_key_id = <POPULATED_BY_AWS-MFA>
+    aws_secret_access_key = <POPULATED_BY_AWS-MFA>
+    aws_security_token = <POPULATED_BY_AWS-MFA>
+
+    [myorganization-staging]
+    aws_access_key_id = <POPULATED_BY_AWS-MFA>
+    aws_secret_access_key = <POPULATED_BY_AWS-MFA>
+    aws_security_token = <POPULATED_BY_AWS-MFA>
+
+    [myorganization-production]
+    aws_access_key_id = <POPULATED_BY_AWS-MFA>
+    aws_secret_access_key = <POPULATED_BY_AWS-MFA>
+    aws_security_token = <POPULATED_BY_AWS-MFA>
+
+This allows you to access multiple environments without the need to run `aws-mfa` each time you want to switch
+environments.
+
+If you don't like the a long term suffix, you can omit it by passing the value ``none`` for the ``--long-term-suffix``
+command line argument. After running ``aws-mfa`` once for each environment with a different value for
+``--short-term-suffix``, your credentials file would read:
+
+.. code-block:: ini
+
+    [myorganization]
+    aws_access_key_id = YOUR_LONGTERM_KEY_ID
+    aws_secret_access_key = YOUR_LONGTERM_ACCESS_KEY
+
+    [myorganization-development]
+    aws_access_key_id = <POPULATED_BY_AWS-MFA>
+    aws_secret_access_key = <POPULATED_BY_AWS-MFA>
+    aws_security_token = <POPULATED_BY_AWS-MFA>
+
+    [myorganization-staging]
+    aws_access_key_id = <POPULATED_BY_AWS-MFA>
+    aws_secret_access_key = <POPULATED_BY_AWS-MFA>
+    aws_security_token = <POPULATED_BY_AWS-MFA>
+
+    [myorganization-production]
+    aws_access_key_id = <POPULATED_BY_AWS-MFA>
+    aws_secret_access_key = <POPULATED_BY_AWS-MFA>
+    aws_security_token = <POPULATED_BY_AWS-MFA>
 
 Usage
 -----
@@ -102,6 +157,17 @@ Usage
     --profile PROFILE       If using profiles, specify the name here. The default
                             profile name is 'default'. The value can also be
                             provided via the environment variable 'AWS_PROFILE'.
+    --long-term-suffix LONG_TERM_SUFFIX
+                            To identify the long term credential section by
+                            [<profile_name>-LONG_TERM_SUFFIX]. Use 'none' to
+                            identify the long term credential section by
+                            [<profile_name>]. Omit to identify the long term 
+                            credential section by [<profile_name>-long-term].
+    --short-term-suffix SHORT_TERM_SUFFIX
+                            To identify the short term credential section by
+                            [<profile_name>-SHORT_TERM_SUFFIX]. Omit or use 'none'
+                            to identify the short term credential section by
+                            [<profile_name>].
     --assume-role arn:aws:iam::123456788990:role/RoleName
                             The ARN of the AWS IAM Role you would like to assume,
                             if specified. This value can also be provided via the

--- a/README.rst
+++ b/README.rst
@@ -264,3 +264,23 @@ Assuming a role using a profile:
     INFO - Obtaining credentials for a new role or profile.
     Enter AWS MFA code for device [arn:aws:iam::123456788990:mfa/dudeman] (renewing for 1800 seconds):123456
     INFO - Success! Your credentials will expire in 1800 seconds at: 2016-10-24 18:58:17+00:00
+
+Assuming a role in multiple accounts and be able to work with both accounts simultaneously (i.e. production an staging):
+
+.. code-block:: sh
+
+    $> aws-mfa —profile myorganization --assume-role arn:aws:iam::222222222222:role/Administrator --short-term-suffix production --long-term-suffix none --role-session-name production
+    INFO - Validating credentials for profile: myorganization-production with assumed role arn:aws:iam::222222222222:role/Administrator
+    INFO - Your credentials have expired, renewing.
+    Enter AWS MFA code for device [arn:aws:iam::111111111111:mfa/me] (renewing for 3600 seconds):123456
+    INFO - Success! Your credentials will expire in 3600 seconds at: 2017-07-10 07:16:43+00:00
+
+    $> aws-mfa —profile myorganization --assume-role arn:aws:iam::333333333333:role/Administrator --short-term-suffix staging --long-term-suffix none --role-session-name staging 
+    INFO - Validating credentials for profile: myorganization-staging with assumed role arn:aws:iam::333333333333:role/Administrator
+    INFO - Your credentials have expired, renewing.
+    Enter AWS MFA code for device [arn:aws:iam::111111111111:mfa/me] (renewing for 3600 seconds):123456
+    INFO - Success! Your credentials will expire in 3600 seconds at: 2017-07-10 07:16:44+00:00
+
+    $> aws s3 list-objects —bucket my-production-bucket —profile myorganization-production
+
+    $> aws s3 list-objects —bucket my-staging-bucket —profile myorganization-staging

--- a/aws-mfa
+++ b/aws-mfa
@@ -102,7 +102,8 @@ def validate(args, config):
         short_term_name = '%s-%s' % (args.profile, args.short_term_suffix)
 
     if long_term_name == short_term_name:
-        log_error_and_exit("The value for '--long-term-suffix' cannot "
+        log_error_and_exit(
+            "The value for '--long-term-suffix' cannot "
             "be equal to the value for '--short-term-suffix'")
 
     if args.assume_role:

--- a/aws-mfa
+++ b/aws-mfa
@@ -1,4 +1,4 @@
-#!/Library/Frameworks/Python.framework/Versions/3.6/bin/python3
+#!/usr/bin/env python
 
 import argparse
 try:

--- a/aws-mfa
+++ b/aws-mfa
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/Library/Frameworks/Python.framework/Versions/3.6/bin/python3
 
 import argparse
 try:
@@ -41,6 +41,14 @@ def main():
                         "also be provided via the environment variable "
                         "'AWS_PROFILE'.",
                         required=False)
+    parser.add_argument('--long-term-suffix',
+                        help="The suffix appended to the profile name to"
+                        "identify the long term credential section",
+                        required=False)
+    parser.add_argument('--short-term-suffix',
+                        help="The suffix appended to the profile name to"
+                        "identify the short term credential section",
+                        required=False)
     parser.add_argument('--assume-role',
                         metavar='arn:aws:iam::123456788990:role/RoleName',
                         help="The ARN of the AWS IAM Role you would like to "
@@ -81,9 +89,22 @@ def validate(args, config):
         else:
             args.profile = 'default'
 
-    short_term_name = args.profile
+    if not args.long_term_suffix:
+        long_term_name = '%s-long-term' % (args.profile,)
+    elif args.long_term_suffix.lower() == 'none':
+        long_term_name = args.profile
+    else:
+        long_term_name = '%s-%s' % (args.profile, args.long_term_suffix)
 
-    long_term_name = '%s-long-term' % (short_term_name,)
+    if not args.short_term_suffix or args.short_term_suffix.lower() == 'none':
+        short_term_name = args.profile
+    else:
+        short_term_name = '%s-%s' % (args.profile, args.short_term_suffix)
+
+    if long_term_name == short_term_name:
+        log_error_and_exit("The value for '--long-term-suffix' cannot "
+            "be equal to the value for '--short-term-suffix'")
+
     if args.assume_role:
         role_msg = "with assumed role %s" % (args.assume_role,)
     else:


### PR DESCRIPTION
I have added two new command line arguments ```--long-term-suffix``` and ```--short-term-suffix``` to be able to override the default naming convention for the credential sections.