### PR TITLE
Delete AWS_PROFILE, so that boto doesn't try and use it

### DIFF
--- a/aws-mfa
+++ b/aws-mfa
@@ -251,6 +251,11 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
                             '(renewing for %s seconds):' %
                             (args.device, args.duration))
 
+    try:
+        del os.environ['AWS_PROFILE']
+    except:
+        pass
+
     client = boto3.client(
         'sts',
         aws_access_key_id=lt_key_id,


### PR DESCRIPTION
Had an issue that produced the following stack trace:
```bash
raceback (most recent call last):
  File "/usr/local/bin/aws-mfa", line 337, in <module>
    main()
  File "/usr/local/bin/aws-mfa", line 86, in main
    validate(args, config)
  File "/usr/local/bin/aws-mfa", line 235, in validate
    get_credentials(short_term_name, key_id, access_key, args, config)
  File "/usr/local/bin/aws-mfa", line 257, in get_credentials
    aws_secret_access_key=lt_access_key
  File "/Library/Python/2.7/site-packages/boto3-1.4.4-py2.7.egg/boto3/__init__.py", line 83, in client
    return _get_default_session().client(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/boto3-1.4.4-py2.7.egg/boto3/__init__.py", line 72, in _get_default_session
    setup_default_session()
  File "/Library/Python/2.7/site-packages/boto3-1.4.4-py2.7.egg/boto3/__init__.py", line 34, in setup_default_session
    DEFAULT_SESSION = Session(**kwargs)
  File "/Library/Python/2.7/site-packages/boto3-1.4.4-py2.7.egg/boto3/session.py", line 80, in __init__
    self._setup_loader()
  File "/Library/Python/2.7/site-packages/boto3-1.4.4-py2.7.egg/boto3/session.py", line 120, in _setup_loader
    self._loader = self._session.get_component('data_loader')
  File "/Library/Python/2.7/site-packages/botocore-1.5.6-py2.7.egg/botocore/session.py", line 701, in get_component
    return self._components.get_component(name)
  File "/Library/Python/2.7/site-packages/botocore-1.5.6-py2.7.egg/botocore/session.py", line 897, in get_component
    self._components[name] = factory()
  File "/Library/Python/2.7/site-packages/botocore-1.5.6-py2.7.egg/botocore/session.py", line 181, in <lambda>
    lambda:  create_loader(self.get_config_variable('data_path')))
  File "/Library/Python/2.7/site-packages/botocore-1.5.6-py2.7.egg/botocore/session.py", line 265, in get_config_variable
    elif self._found_in_config_file(methods, var_config):
  File "/Library/Python/2.7/site-packages/botocore-1.5.6-py2.7.egg/botocore/session.py", line 286, in _found_in_config_file
    return var_config[0] in self.get_scoped_config()
  File "/Library/Python/2.7/site-packages/botocore-1.5.6-py2.7.egg/botocore/session.py", line 358, in get_scoped_config
    raise ProfileNotFound(profile=profile_name)
botocore.exceptions.ProfileNotFound: The config profile (ptml) could not be found
```

I could work around it by creating an empty section inside ~/.aws/credentials.  This is possibly a bug in boto3, but this PR provides a cleaner workaround.
