### PR TITLE
if present, copy 'region' from long-term to short-term config

### DIFF
--- a/aws-mfa
+++ b/aws-mfa
@@ -239,7 +239,9 @@ def validate(args, config):
                 % (diff.total_seconds(), exp))
 
     if should_refresh:
-        get_credentials(short_term_name, key_id, access_key, args, config)
+        get_credentials(
+            short_term_name, long_term_name, key_id, access_key, args, config
+        )
 
 
 def log_error_and_exit(message):
@@ -248,7 +250,9 @@ def log_error_and_exit(message):
     sys.exit(1)
 
 
-def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
+def get_credentials(
+    short_term_name, long_term_name, lt_key_id, lt_access_key, args, config
+):
     try:
         token_input = raw_input
     except NameError:

--- a/aws-mfa
+++ b/aws-mfa
@@ -327,6 +327,13 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
         'expiration',
         response['Credentials']['Expiration'].strftime('%Y-%m-%d %H:%M:%S')
     )
+    # set region on short term if set on long term
+    if config.has_option(long_term_name, 'region'):
+        config.set(
+            short_term_name,
+            'region',
+            config.get(long_term_name, 'region')
+        )
     with open(AWS_CREDS_PATH, 'w') as configfile:
         config.write(configfile)
     logger.info(


### PR DESCRIPTION
This is a wonderful tool, thanks so much! It does really simplify using MFA-enabled API access.

This is mainly a convenience; if the ``region`` option is set in the long-term config section, it copies it to the short term section before writing out the config file.