### PR TITLE
Add the ability to assume a role without entering MFA 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,18 @@ Usage
     --role-session-name ROLE_SESSION_NAME
                             Friendly session name required when using --assume-
                             role. By default, this is your local username.
+    --use-short-term-credentials USE_SHORT_TERM_CREDENTIALS
+                            If you already have a short term profile set with a
+                            session token and that user doesn't require MFA to
+                            assume the role, use the short-term credentials
+                            without needing to enter a token. used with --assume-
+                            role
+    --role-profile-name ROLE_PROFILE_NAME
+                            Set a custom profile name when using --use-short-term-
+                            credentials and --assume-role so that the short-term
+                            profile with temporary credentials isn't overwritten.
+                            Will identify a new short term credential section by
+                            [<profile_name>-ROLE_PROFILE_NAME]
 
 **Argument precedence**: Command line arguments take precedence over environment variables.
 
@@ -297,3 +309,12 @@ Assuming a role in multiple accounts and be able to work with both accounts simu
     $> aws s3 list-objects —bucket my-production-bucket —profile myorganization-production
 
     $> aws s3 list-objects —bucket my-staging-bucket —profile myorganization-staging
+
+Assuming you've already authenticated with MFA as an IAM user, and want to use those short term credentials without MFA device when assuming roles
+
+.. code-block:: sh
+    aws-mfa --device arn:aws:iam::123456788990:mfa/dudeman --profile development --assume-role arn:aws:iam::98765432110:role/MyRoleInAnotherAccount --role-session-name some-role --use-short-term-credentials True --role-profile-name my-role
+    INFO - Validating credentials for profile: development with assumed role: arn:aws:iam::98765432110:role/MyRoleInAnotherAccount
+    INFO - Short term credentials section development-my-role is missing, obtaining new credentials.
+    INFO - Assuming Role - Profile: development-my-role, Role: arn:aws:iam::98765432110:role/MyRoleInAnotherAccount, Duration: 3600
+    INFO - Success! Your credentials will expire in 3600 seconds at: 2018-02-02 21:31:16+00:00

--- a/README.rst
+++ b/README.rst
@@ -175,18 +175,11 @@ Usage
     --role-session-name ROLE_SESSION_NAME
                             Friendly session name required when using --assume-
                             role. By default, this is your local username.
-    --use-short-term-credentials USE_SHORT_TERM_CREDENTIALS
-                            If you already have a short term profile set with a
-                            session token and that user doesn't require MFA to
-                            assume the role, use the short-term credentials
-                            without needing to enter a token. used with --assume-
-                            role
-    --role-profile-name ROLE_PROFILE_NAME
-                            Set a custom profile name when using --use-short-term-
-                            credentials and --assume-role so that the short-term
-                            profile with temporary credentials isn't overwritten.
-                            Will identify a new short term credential section by
-                            [<profile_name>-ROLE_PROFILE_NAME]
+    --no-mfa-prompt NO_MFA_PROMPT
+                            If you've already created short-term
+                            credentials and don't want to be prompted for
+                            your MFA token when assuming a role, use this flag.
+                            Used with --assume-role
 
 **Argument precedence**: Command line arguments take precedence over environment variables.
 
@@ -310,11 +303,19 @@ Assuming a role in multiple accounts and be able to work with both accounts simu
 
     $> aws s3 list-objects —bucket my-staging-bucket —profile myorganization-staging
 
-Assuming you've already authenticated with MFA as an IAM user, and want to use those short term credentials without MFA device when assuming roles
+If a profile with short-term credentials has the permissions to assume a role _without_ entering an MFA token, you can add the `--no-mfa-prompt` flag to not prompt you for the MFA token.
 
 .. code-block:: sh
-    aws-mfa --device arn:aws:iam::123456788990:mfa/dudeman --profile development --assume-role arn:aws:iam::98765432110:role/MyRoleInAnotherAccount --role-session-name some-role --use-short-term-credentials True --role-profile-name my-role
-    INFO - Validating credentials for profile: development with assumed role: arn:aws:iam::98765432110:role/MyRoleInAnotherAccount
-    INFO - Short term credentials section development-my-role is missing, obtaining new credentials.
-    INFO - Assuming Role - Profile: development-my-role, Role: arn:aws:iam::98765432110:role/MyRoleInAnotherAccount, Duration: 3600
-    INFO - Success! Your credentials will expire in 3600 seconds at: 2018-02-02 21:31:16+00:00
+
+    $> aws-mfa --profile myorganization --device arn:aws:iam::123456788990:mfa/dudeman
+    INFO - Validating credentials for profile: myorganization
+    INFO - Short term credentials section myorganization is missing, obtaining new credentials.
+    Enter AWS MFA code for device [arn:aws:iam::123456788990:mfa/dudeman] (renewing for 43200 seconds):953051
+    INFO - Fetching Credentials - Profile: myorganization, Duration: 43200
+    INFO - Success! Your credentials will expire in 43200 seconds at: 2018-02-06 03:54:40+00:00
+
+    $> aws-mfa --profile myorganization --long-term-suffix none --short-term-suffix audit-role --assume-role arn:aws:iam::222222222222:role/AuditRole --role-session-name some-session --no-mfa-prompt True
+    INFO - Validating credentials for profile: myorganization-audit-role with assumed role: arn:aws:iam::222222222222:role/AuditRole
+    INFO - Short term credentials section myorganization-audit-role is missing, obtaining new credentials.
+    INFO - Assuming Role - Profile: myorganization-audit-role, Role: arn:aws:iam::222222222222:role/AuditRole, Duration: 3600
+    INFO - Success! Your credentials will expire in 3600 seconds at: 2018-02-05 16:55:54+00:00

--- a/aws-mfa
+++ b/aws-mfa
@@ -62,6 +62,19 @@ def main():
                         "--assume-role",
                         default=getpass.getuser(),
                         required=False)
+    parser.add_argument('--use-short-term-credentials',
+                        help="If you already have a short term profile set "
+                        "with a session token and that user doesn't require "
+                        "MFA to assume the role, use the short-term "
+                        "credentials without needing to enter a token. "
+                        "used with --assume-role",
+                        required=False)
+    parser.add_argument('--role-profile-name',
+                        help="Set a custom profile name when using "
+                        "--use-short-term-credentials and --assume-role "
+                        "so that the short-term profile with "
+                        "temporary credentials isn't overwritten",
+                        required=False)
     parser.add_argument('--force',
                         help="Refresh credentials even if currently valid.",
                         action="store_true",
@@ -129,17 +142,37 @@ def validate(args, config):
                 (short_term_name, role_msg))
     reup_message = "Obtaining credentials for a new role or profile."
 
-    try:
-        key_id = config.get(long_term_name, 'aws_access_key_id')
-        access_key = config.get(long_term_name, 'aws_secret_access_key')
-    except NoSectionError:
-        log_error_and_exit(
-            "Long term credentials session '[%s]' is missing. "
-            "You must add this section to your credentials file "
-            "along with your long term 'aws_access_key_id' and "
-            "'aws_secret_access_key'" % (long_term_name,))
-    except NoOptionError as e:
-        log_error_and_exit(e)
+    aws_creds = {}
+    if args.use_short_term_credentials:
+        try:
+            aws_creds = {
+                "key_id": config.get(short_term_name, 'aws_access_key_id'),
+                "access_key": config.get(short_term_name, 'aws_secret_access_key'),
+                "session_token": config.get(short_term_name, 'aws_session_token')
+            }
+
+        except NoSectionError:
+            log_error_and_exit(
+                "Long term credentials session '[%s]' is missing. "
+                "You must add this section to your credentials file "
+                "along with your long term 'aws_access_key_id', "
+                "'aws_secret_access_key' and 'aws_session_token'" % (long_term_name,))
+        except NoOptionError as e:
+            log_error_and_exit(e)
+    else:
+        try:
+            aws_creds = {
+                "key_id": config.get(long_term_name, 'aws_access_key_id'),
+                "access_key": config.get(long_term_name, 'aws_secret_access_key')
+            }
+        except NoSectionError:
+            log_error_and_exit(
+                "Long term credentials session '[%s]' is missing. "
+                "You must add this section to your credentials file "
+                "along with your long term 'aws_access_key_id' and "
+                "'aws_secret_access_key'" % (long_term_name,))
+        except NoOptionError as e:
+            log_error_and_exit(e)
 
     # get device from param, env var or config
     if not args.device:
@@ -165,6 +198,10 @@ def validate(args, config):
             args.duration = int(os.environ.get('MFA_STS_DURATION'))
         else:
             args.duration = 3600 if args.assume_role else 43200
+
+    if args.role_profile_name:
+        short_term_name = "{}-{}".format(short_term_name,
+                                         args.role_profile_name)
 
     # If this is False, only refresh credentials if expired. Otherwise
     # always refresh.
@@ -247,7 +284,7 @@ def validate(args, config):
                 % (diff.total_seconds(), exp))
 
     if should_refresh:
-        get_credentials(short_term_name, key_id, access_key, args, config)
+        get_credentials(short_term_name, aws_creds, args, config)
 
 
 def log_error_and_exit(message):
@@ -256,21 +293,21 @@ def log_error_and_exit(message):
     sys.exit(1)
 
 
-def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
+def get_credentials(short_term_name, aws_creds, args, config):
     try:
         token_input = raw_input
     except NameError:
         token_input = input
 
-    mfa_token = token_input('Enter AWS MFA code for device [%s] '
-                            '(renewing for %s seconds):' %
-                            (args.device, args.duration))
-
-    client = boto3.client(
-        'sts',
-        aws_access_key_id=lt_key_id,
-        aws_secret_access_key=lt_access_key
-    )
+    if not args.use_short_term_credentials:
+        mfa_token = token_input('Enter AWS MFA code for device [%s] '
+                                '(renewing for %s seconds):' %
+                                (args.device, args.duration))
+        client = boto3.client(
+            'sts',
+            aws_access_key_id=aws_creds['key_id'],
+            aws_secret_access_key=aws_creds['access_key']
+        )
 
     if args.assume_role:
 
@@ -280,13 +317,26 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
             log_error_and_exit("You must specify a role session name "
                                "via --role-session-name")
 
-        response = client.assume_role(
-            RoleArn=args.assume_role,
-            RoleSessionName=args.role_session_name,
-            DurationSeconds=args.duration,
-            SerialNumber=args.device,
-            TokenCode=mfa_token
-        )
+        if args.use_short_term_credentials:
+            client = boto3.client(
+                'sts',
+                aws_access_key_id=aws_creds['key_id'],
+                aws_secret_access_key=aws_creds['access_key'],
+                aws_session_token=aws_creds['session_token']
+            )
+            response = client.assume_role(
+                RoleArn=args.assume_role,
+                RoleSessionName=args.role_session_name,
+                DurationSeconds=args.duration
+            )
+        else:
+            response = client.assume_role(
+                RoleArn=args.assume_role,
+                RoleSessionName=args.role_session_name,
+                DurationSeconds=args.duration,
+                SerialNumber=args.device,
+                TokenCode=mfa_token
+            )
 
         config.set(
             short_term_name,

--- a/aws-mfa
+++ b/aws-mfa
@@ -147,8 +147,14 @@ def validate(args, config):
         try:
             aws_creds = {
                 "key_id": config.get(short_term_name, 'aws_access_key_id'),
-                "access_key": config.get(short_term_name, 'aws_secret_access_key'),
-                "session_token": config.get(short_term_name, 'aws_session_token')
+                "access_key": config.get(
+                    short_term_name,
+                    'aws_secret_access_key'
+                ),
+                "session_token": config.get(
+                    short_term_name,
+                    'aws_session_token'
+                )
             }
 
         except NoSectionError:
@@ -156,14 +162,21 @@ def validate(args, config):
                 "Long term credentials session '[%s]' is missing. "
                 "You must add this section to your credentials file "
                 "along with your long term 'aws_access_key_id', "
-                "'aws_secret_access_key' and 'aws_session_token'" % (long_term_name,))
+                "'aws_secret_access_key' and "
+                "'aws_session_token'" % (long_term_name,))
         except NoOptionError as e:
             log_error_and_exit(e)
     else:
         try:
             aws_creds = {
-                "key_id": config.get(long_term_name, 'aws_access_key_id'),
-                "access_key": config.get(long_term_name, 'aws_secret_access_key')
+                "key_id": config.get(
+                    long_term_name,
+                    'aws_access_key_id'
+                ),
+                "access_key": config.get(
+                    long_term_name,
+                    'aws_secret_access_key'
+                )
             }
         except NoSectionError:
             log_error_and_exit(

--- a/aws-mfa
+++ b/aws-mfa
@@ -62,18 +62,11 @@ def main():
                         "--assume-role",
                         default=getpass.getuser(),
                         required=False)
-    parser.add_argument('--use-short-term-credentials',
-                        help="If you already have a short term profile set "
-                        "with a session token and that user doesn't require "
-                        "MFA to assume the role, use the short-term "
-                        "credentials without needing to enter a token. "
-                        "used with --assume-role",
-                        required=False)
-    parser.add_argument('--role-profile-name',
-                        help="Set a custom profile name when using "
-                        "--use-short-term-credentials and --assume-role "
-                        "so that the short-term profile with "
-                        "temporary credentials isn't overwritten",
+    parser.add_argument('--no-mfa-prompt',
+                        help="If you've already created short-term "
+                        "credentials and don't want to be prompted for "
+                        "your MFA token when assuming a role, use this flag. "
+                        "Used with --assume-role",
                         required=False)
     parser.add_argument('--force',
                         help="Refresh credentials even if currently valid.",
@@ -142,50 +135,24 @@ def validate(args, config):
                 (short_term_name, role_msg))
     reup_message = "Obtaining credentials for a new role or profile."
 
-    aws_creds = {}
-    if args.use_short_term_credentials:
-        try:
-            aws_creds = {
-                "key_id": config.get(short_term_name, 'aws_access_key_id'),
-                "access_key": config.get(
-                    short_term_name,
-                    'aws_secret_access_key'
-                ),
-                "session_token": config.get(
-                    short_term_name,
-                    'aws_session_token'
-                )
-            }
-
-        except NoSectionError:
-            log_error_and_exit(
-                "Long term credentials session '[%s]' is missing. "
-                "You must add this section to your credentials file "
-                "along with your long term 'aws_access_key_id', "
-                "'aws_secret_access_key' and "
-                "'aws_session_token'" % (long_term_name,))
-        except NoOptionError as e:
-            log_error_and_exit(e)
-    else:
-        try:
-            aws_creds = {
-                "key_id": config.get(
-                    long_term_name,
-                    'aws_access_key_id'
-                ),
-                "access_key": config.get(
-                    long_term_name,
-                    'aws_secret_access_key'
-                )
-            }
-        except NoSectionError:
-            log_error_and_exit(
-                "Long term credentials session '[%s]' is missing. "
-                "You must add this section to your credentials file "
-                "along with your long term 'aws_access_key_id' and "
-                "'aws_secret_access_key'" % (long_term_name,))
-        except NoOptionError as e:
-            log_error_and_exit(e)
+    try:
+        aws_creds = {
+            "aws_access_key_id": config.get(
+                long_term_name, 'aws_access_key_id'),
+            "aws_secret_access_key": config.get(
+                long_term_name, 'aws_secret_access_key')
+        }
+        if args.no_mfa_prompt:
+            aws_creds['aws_session_token'] = config.get(
+                long_term_name, 'aws_session_token')
+    except NoSectionError:
+        log_error_and_exit(
+            "Long term credentials session '[%s]' is missing. "
+            "You must add this section to your credentials file "
+            "along with your long term 'aws_access_key_id' and "
+            "'aws_secret_access_key'" % (long_term_name,))
+    except NoOptionError as e:
+        log_error_and_exit(e)
 
     # get device from param, env var or config
     if not args.device:
@@ -211,10 +178,6 @@ def validate(args, config):
             args.duration = int(os.environ.get('MFA_STS_DURATION'))
         else:
             args.duration = 3600 if args.assume_role else 43200
-
-    if args.role_profile_name:
-        short_term_name = "{}-{}".format(short_term_name,
-                                         args.role_profile_name)
 
     # If this is False, only refresh credentials if expired. Otherwise
     # always refresh.
@@ -312,14 +275,15 @@ def get_credentials(short_term_name, aws_creds, args, config):
     except NameError:
         token_input = input
 
-    if not args.use_short_term_credentials:
+    if not args.no_mfa_prompt:
         mfa_token = token_input('Enter AWS MFA code for device [%s] '
                                 '(renewing for %s seconds):' %
                                 (args.device, args.duration))
+
         client = boto3.client(
             'sts',
-            aws_access_key_id=aws_creds['key_id'],
-            aws_secret_access_key=aws_creds['access_key']
+            aws_access_key_id=aws_creds['aws_access_key_id'],
+            aws_secret_access_key=aws_creds['aws_secret_access_key']
         )
 
     if args.assume_role:
@@ -329,13 +293,12 @@ def get_credentials(short_term_name, aws_creds, args, config):
         if args.role_session_name is None:
             log_error_and_exit("You must specify a role session name "
                                "via --role-session-name")
-
-        if args.use_short_term_credentials:
+        if args.no_mfa_prompt:
             client = boto3.client(
                 'sts',
-                aws_access_key_id=aws_creds['key_id'],
-                aws_secret_access_key=aws_creds['access_key'],
-                aws_session_token=aws_creds['session_token']
+                aws_access_key_id=aws_creds['aws_access_key_id'],
+                aws_secret_access_key=aws_creds['aws_secret_access_key'],
+                aws_session_token=aws_creds['aws_session_token']
             )
             response = client.assume_role(
                 RoleArn=args.assume_role,


### PR DESCRIPTION
This project is great!
This PR attempts to address a use case I have on a daily basis.

We have an Identity AWS account where we have IAM users, then multiple accounts with roles we can assume.  In the Identity account, we must be authenticated with MFA in order to assume roles.

Once I'm authenticated with MFA ([`get_session_token`](https://boto3.readthedocs.io/en/latest/reference/services/sts.html#STS.Client.get_session_token)), I'd like the option to seamlessly assume roles in other accounts without having to key in my MFA code each time, so I want to pass the short-term credentials to the boto3 client.