### PR TITLE
Adds --token as an optional argument

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -79,9 +79,9 @@ def main():
                         help="Setup a new log term credentials section",
                         action="store_true",
                         required=False)
-    parser.add_argument('--token',
+    parser.add_argument('--token', '--mfa-token'
                         type=str,
-                        help="Provide token as an argument",
+                        help="Provide MFA token as an argument",
                         required=False)
     args = parser.parse_args()
 

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -79,6 +79,9 @@ def main():
                         help="Setup a new log term credentials section",
                         action="store_true",
                         required=False)
+    parser.add_argument('--token',
+                        help="Provide token as an argument",
+                        required=False)
     args = parser.parse_args()
 
     level = getattr(logging, args.log_level)
@@ -273,10 +276,14 @@ def validate(args, config):
 
 
 def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
-    console_input = prompter()
-    mfa_token = console_input('Enter AWS MFA code for device [%s] '
-                              '(renewing for %s seconds):' %
-                              (args.device, args.duration))
+    if args.token:
+        logger.debug("Received token as argument")
+        mfa_token = '%s' % (args.token)
+    else:
+        console_input = prompter()
+        mfa_token = console_input('Enter AWS MFA code for device [%s] '
+                                '(renewing for %s seconds):' %
+                                (args.device, args.duration))
 
     client = boto3.client(
         'sts',

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -79,7 +79,7 @@ def main():
                         help="Setup a new log term credentials section",
                         action="store_true",
                         required=False)
-    parser.add_argument('--token', '--mfa-token'
+    parser.add_argument('--token', '--mfa-token',
                         type=str,
                         help="Provide MFA token as an argument",
                         required=False)

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -80,6 +80,7 @@ def main():
                         action="store_true",
                         required=False)
     parser.add_argument('--token',
+                        type=str,
                         help="Provide token as an argument",
                         required=False)
     args = parser.parse_args()

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -283,8 +283,8 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
     else:
         console_input = prompter()
         mfa_token = console_input('Enter AWS MFA code for device [%s] '
-                                '(renewing for %s seconds):' %
-                                (args.device, args.duration))
+                                  '(renewing for %s seconds):' %
+                                  (args.device, args.duration))
 
     client = boto3.client(
         'sts',


### PR DESCRIPTION
Allows for optional argument `--token` to be provided along with the token. If this argument is omitted, the existing interactive prompt logic still applies.