### PR TITLE
Fix parameter validation error message

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -312,8 +312,8 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
             log_error_and_exit(logger,
                                "An error occured while calling "
                                "assume role: {}".format(e))
-        except ParamValidationError:
-            log_error_and_exit(logger, "Token must be six digits")
+        except ParamValidationError as e:
+            log_error_and_exit(logger, getattr(e, 'message', repr(e)))
 
         config.set(
             short_term_name,
@@ -338,10 +338,8 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
             log_error_and_exit(
                 logger,
                 "An error occured while calling assume role: {}".format(e))
-        except ParamValidationError:
-            log_error_and_exit(
-                logger,
-                "Token must be six digits")
+        except ParamValidationError as e:
+            log_error_and_exit(logger, getattr(e, 'message', repr(e)))
 
         config.set(
             short_term_name,


### PR DESCRIPTION
closes #36 

When using a session duration of less than 900 seconds aws-mfa prints a misleading error message "Token must be six digits".

This PR prints the actual error. In the case of an invalid duration it will print the following:

```
INFO - Fetching Credentials - Profile: <profile>, Duration: 800
ERROR - Parameter validation failed:
Invalid range for parameter DurationSeconds, value: 800, valid range: 900-inf
``` 