### PR TITLE
Add warning if AWS config already present

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -272,6 +272,8 @@ def validate(args, config):
                 " they will expire at %s"
                 % (diff.total_seconds(), exp))
 
+            warn_on_existing_aws_env()
+
     if should_refresh:
         get_credentials(short_term_name, key_id, access_key, args, config)
 
@@ -376,7 +378,20 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
     logger.info(
         "Success! Your credentials will expire in %s seconds at: %s"
         % (args.duration, response['Credentials']['Expiration']))
+
+    warn_on_existing_aws_env()
+
     sys.exit(0)
+
+
+def warn_on_existing_aws_env():
+    # https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#config-settings-and-precedence
+    aws_keys = list(filter(lambda k: k in os.environ,
+                           ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN']))
+    if aws_keys:
+        logger.warning('Your env already has AWS access keys set %s, which take precedence in the AWS CLI and SDKs '
+                       'over the credentials written by this utility. Consider `unset`-ting them if you have issues.'
+                       % aws_keys)
 
 
 def setup_logger(level=logging.DEBUG):


### PR DESCRIPTION
Not a shortcoming of `aws-mfa` (which is really useful, thank you), but I've seen many people in my group fall foul of having `AWS_` tokens already present in their env, using `aws-mfa`, and wondering why the CLI doesn't work.

This spits out a warning (on auth, or on the 'still-valid' message) to those users who have overriding env vars set in their shell. 

```
INFO - Validating credentials for profile: derp
INFO - Your credentials have expired, renewing.
Enter AWS MFA code for device [arn:aws:iam::123456789:mfa/herp.derp] (renewing for 43200 seconds):605957
INFO - Fetching Credentials - Profile: derp, Duration: 43200
INFO - Success! Your credentials will expire in 43200 seconds at: 2019-07-02 03:06:05+00:00
WARNING - Your env already has AWS access keys set ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'], which will take precedence in the AWS CLI/SDK over the credentials created by this utility. Consider `unset`-ting them if you have issues.
```
