### PR TITLE
Verify device arn is an mfa device.

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -178,6 +178,11 @@ def validate(args, config):
                                'You must provide --device or MFA_DEVICE or set '
                                '"aws_mfa_device" in ".aws/credentials"')
 
+    # verify device arn is an mfa device
+    if 'mfa' not in args.device:
+        log_error_and_exit(logger, "%s does not appear to be an MFA device."
+                           % args.device)
+
     # get assume_role from param or env var
     if not args.assume_role:
         if os.environ.get('MFA_ASSUME_ROLE'):


### PR DESCRIPTION
A common mistake is for people to try to to authenticate using their user ARN instead of their MFA ARN. This change set validates the ARN as being an MFA ARN.

Example bad ARN:
```
arn:aws:iam::123456789012:user/somebody
```

Example of attempting to use this bad ARN:
```
$ aws-mfa --device arn:aws:iam::123456789012:user/somebody
INFO - Validating credentials for profile: default
ERROR - arn:aws:iam::123456789012:user/somebody does not appear to be an MFA device.
```

Example good ARN:
```
arn:aws:iam::123456789012:mfa/somebody
```

Example of attempting to use this good ARN (this will be identical to the output from before this change):
```
$ aws-mfa --device arn:aws:iam::123456789012:mfa/somebody
INFO - Validating credentials for profile: default
INFO - Your credentials are still valid for 41764.586892 seconds they will expire at 2021-03-25 06:29:10
```
