### PR TITLE
Show error from exception

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -312,8 +312,8 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
             log_error_and_exit(logger,
                                "An error occured while calling "
                                "assume role: {}".format(e))
-        except ParamValidationError:
-            log_error_and_exit(logger, "Token must be six digits")
+        except ParamValidationError, e:
+            log_error_and_exit(logger, "Token must be six digits: %s" % e)
 
         config.set(
             short_term_name,
@@ -338,10 +338,10 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
             log_error_and_exit(
                 logger,
                 "An error occured while calling assume role: {}".format(e))
-        except ParamValidationError:
+        except ParamValidationError, e:
             log_error_and_exit(
                 logger,
-                "Token must be six digits")
+                "Token must be six digits: %s" % e)
 
         config.set(
             short_term_name,


### PR DESCRIPTION
Current implementation hides detailed error from server under "Token must be six digits" that might be confusing.

The patch adds exception details that exposes proper error reason, for example:

* Invalid range for parameter DurationSeconds, value: 300, valid range: 900-inf