### PR TITLE
Respect AWS_SHARED_CREDENTIALS_FILE env variable

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -18,7 +18,7 @@ from awsmfa.util import log_error_and_exit, prompter
 
 logger = logging.getLogger('aws-mfa')
 
-AWS_CREDS_PATH = '%s/.aws/credentials' % (os.path.expanduser('~'),)
+AWS_CREDS_PATH = os.path.expanduser(os.environ.get('AWS_SHARED_CREDENTIALS_FILE', '~/.aws/credentials'))
 
 
 def main():


### PR DESCRIPTION
Current implementation has hardcoded AWS_CREDS_PATH. 

This patch modifies it to respect AWS_SHARED_CREDENTIALS_FILE if set, otherwise to default.