### PR TITLE
Use aws credentials path if available

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -18,7 +18,9 @@ from awsmfa.util import log_error_and_exit, prompter
 
 logger = logging.getLogger('aws-mfa')
 
-AWS_CREDS_PATH = '%s/.aws/credentials' % (os.path.expanduser('~'),)
+AWS_CREDS_PATH = os.getenv('AWS_SHARED_CREDENTIALS_FILE')
+if AWS_CREDS_PATH == None:
+    AWS_CREDS_PATH = '%s/.aws/credentials' % (os.path.expanduser('~'),)
 
 
 def main():


### PR DESCRIPTION
aws-mfa is hardcoding the credentials file path to ~ but as per the AWS documentation, it has to be fetched from  AWS_SHARED_CREDENTIALS_FILE if it is available.

Refer: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html