### PR TITLE
Add support for store MFA duration in config of profile

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -37,7 +37,8 @@ def main():
                              "Defaults to 43200 (12 hours), or 3600 (one "
                              "hour) when using '--assume-role'. This value "
                              "can also be provided via the environment "
-                             "variable 'MFA_STS_DURATION'. ")
+                             "variable 'MFA_STS_DURATION' or the"
+                             " ~/.aws/credentials variable 'aws_mfa_duration'.")
     parser.add_argument('--profile',
                         help="If using profiles, specify the name here. The "
                         "default profile name is 'default'. The value can "
@@ -189,6 +190,8 @@ def validate(args, config):
     if not args.duration:
         if os.environ.get('MFA_STS_DURATION'):
             args.duration = int(os.environ.get('MFA_STS_DURATION'))
+        elif config.has_option(long_term_name, 'aws_mfa_duration'):
+            args.duration = int(config.get(long_term_name, 'aws_mfa_duration'))
         else:
             args.duration = 3600 if args.assume_role else 43200
 


### PR DESCRIPTION
I would like configure in `~/.aws/credentials` to use short time for production environment. I would like to reduce the access time to the production environment so as not to accidentally make changes to production when I do something else and forget that I work in production. I'd like to cut production time from hours to minutes, as this should be enough time to apply changes that have been tested in other environments. 