### PR TITLE
fix: add aws-mfa.bat to allow for script to be run from CMD PATH

### DIFF
--- a/aws-mfa.bat
+++ b/aws-mfa.bat
@@ -1,0 +1,1 @@
+python "%~dp0\aws-mfa" %*

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author='Brian Nuszkowski',
     author_email='brian@bnuz.co',
     packages=['awsmfa'],
-    scripts=['aws-mfa'],
+    scripts=['aws-mfa', 'aws-mfa.bat'],
     entry_points={
         'console_scripts': [
             'aws-mfa=awsmfa:main',


### PR DESCRIPTION
Currently installs on Windows CMD/Powershell are not able to run `aws-mfa` since it wont pick up on the shell script in the `PATH`, so adding a `.bat` file that runs the script will make it available. 