### PR TITLE
Support setting the suffixes via environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,14 @@ Usage
                         identify the long term credential section by
                         [<profile_name>]. Omit to identify the long term 
                         credential section by [<profile_name>-long-term].
+                        The value can also be provided via the environment
+                        variable 'MFA_LONG_TERM_SUFFIX.
 --short-term-suffix SHORT_TERM_SUFFIX
                         To identify the short term credential section by
                         [<profile_name>-SHORT_TERM_SUFFIX]. Omit or use 'none'
                         to identify the short term credential section by
-                        [<profile_name>].
+                        [<profile_name>]. The value can also be provided via 
+                        the environment variable 'MFA_SHORT_TERM_SUFFIX.
 --assume-role arn:aws:iam::123456788990:role/RoleName
                         The ARN of the AWS IAM Role you would like to assume,
                         if specified. This value can also be provided via the

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -133,10 +133,11 @@ def validate(args, config):
             long_term_name = '%s-%s' % (args.profile, args.long_term_suffix)
         else:
             long_term_name = '%s-long-term' % (args.profile,)
-    elif args.long_term_suffix.lower() == 'none':
-        long_term_name = args.profile
     else:
         long_term_name = '%s-%s' % (args.profile, args.long_term_suffix)
+    if args.long_term_suffix.lower() == 'none':
+        long_term_name = args.profile
+    logger.debug('Using long term name: %s' % (long_term_name,))
 
     if not args.short_term_suffix or args.short_term_suffix.lower() == 'none':
         if os.environ.get('MFA_SHORT_TERM_SUFFIX'):
@@ -146,12 +147,12 @@ def validate(args, config):
             short_term_name = args.profile
     else:
         short_term_name = '%s-%s' % (args.profile, args.short_term_suffix)
+    logger.debug('Using short term name: %s' % (short_term_name,))
 
     if long_term_name == short_term_name:
         log_error_and_exit(logger,
                            "The value for '--long-term-suffix' cannot "
                            "be equal to the value for '--short-term-suffix'")
-
     if args.assume_role:
         role_msg = "with assumed role: %s" % (args.assume_role,)
     elif config.has_option(args.profile, 'assumed_role_arn'):

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -128,14 +128,22 @@ def validate(args, config):
             args.profile = 'default'
 
     if not args.long_term_suffix:
-        long_term_name = '%s-long-term' % (args.profile,)
+        if os.environ.get('MFA_LONG_TERM_SUFFIX'):
+            args.long_term_suffix = os.environ.get('MFA_LONG_TERM_SUFFIX')
+            long_term_name = '%s-%s' % (args.profile, args.long_term_suffix)
+        else:
+            long_term_name = '%s-long-term' % (args.profile,)
     elif args.long_term_suffix.lower() == 'none':
         long_term_name = args.profile
     else:
         long_term_name = '%s-%s' % (args.profile, args.long_term_suffix)
 
     if not args.short_term_suffix or args.short_term_suffix.lower() == 'none':
-        short_term_name = args.profile
+        if os.environ.get('MFA_SHORT_TERM_SUFFIX'):
+            args.short_term_suffix = os.environ.get('MFA_SHORT_TERM_SUFFIX')
+            short_term_name = '%s-%s' % (args.profile, args.short_term_suffix)
+        else:
+            short_term_name = args.profile
     else:
         short_term_name = '%s-%s' % (args.profile, args.short_term_suffix)
 


### PR DESCRIPTION
If the user wants to consistently use a different convention for the two suffixes, it is a bit inconvenient to set them each time a user wants to generate updated credentials.

As such, I propose being able to configure both suffixes via the environment variables `MFA_LONG_TERM_SUFFIX` and `MFA_SHORT_TERM_SUFFIX`.
