### PR TITLE
Adding additional argument to provide custom Credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ Usage
 -----
 
 ```
+--credentials-filepath '\custom_path\.aws\credentials'
+                        Specify AWS Credentials filepath to be used
+                        instead of default Credentials file.'.
 --device arn:aws:iam::123456788990:mfa/dudeman
                         The MFA Device ARN. This value can also be provided
                         via the environment variable 'MFA_DEVICE' or the

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -22,7 +22,13 @@ AWS_CREDS_PATH = '%s/.aws/credentials' % (os.path.expanduser('~'),)
 
 
 def main():
+    global AWS_CREDS_PATH
     parser = argparse.ArgumentParser()
+    parser.add_argument('--credentials-filepath',
+                        required=False,
+                        metavar='\custom_path\.aws\credentials',
+                        help="Specify AWS Credentials filepath to be used "
+                        "instead of default Credentials file.") 
     parser.add_argument('--device',
                         required=False,
                         metavar='arn:aws:iam::123456788990:mfa/dudeman',
@@ -87,6 +93,10 @@ def main():
 
     level = getattr(logging, args.log_level)
     setup_logger(level)
+
+    # Use user provided Credentials file
+    if args.credentials_filepath:
+        AWS_CREDS_PATH = args.credentials_filepath;
 
     if not os.path.isfile(AWS_CREDS_PATH):
         console_input = prompter()


### PR DESCRIPTION
With WSL2 running on windows, it is common to have multiple aws credential file, for example, one on the windows machine and another on a WSL2 machine. With this change, the end-user can specify the Credentials file to be updated.