### PR TITLE
Fix profile arg not being used in aws-cli/2.11.4

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -286,7 +286,8 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
                                   '(renewing for %s seconds):' %
                                   (args.device, args.duration))
 
-    client = boto3.client(
+    session = boto3.session.Session(profile_name=short_term_name)
+    client = session.client(
         'sts',
         aws_access_key_id=lt_key_id,
         aws_secret_access_key=lt_access_key


### PR DESCRIPTION
This addresses issue https://github.com/broamski/aws-mfa/issues/83

Tested with `aws-cli/2.11.4` for fixing the immediate issue and `aws-cli/2.9.22` for ensuring backwards compat.