### PR TITLE
Adding QRCODE secret as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ Usage
 --role-session-name ROLE_SESSION_NAME
                         Friendly session name required when using --assume-
                         role. By default, this is your local username.
+--qrcode QRCODE         If using QRCODE secret as an argument, calculates
+                        totp internally.
+                     
 ```
 
 **Argument precedence**: Command line arguments take precedence over environment variables.
@@ -286,4 +289,11 @@ INFO - Success! Your credentials will expire in 3600 seconds at: 2017-07-10 07:1
 $> aws s3 list-objects —bucket my-production-bucket —profile myorganization-production
 
 $> aws s3 list-objects —bucket my-staging-bucket —profile myorganization-staging
+```
+Using qrcode secret as an argument, so calculates qrcode internally
+
+```sh
+$> aws-mfa --device arn:aws:iam::123456788990:mfa/dudeman --profile development --qrcode 1234456789012344567890123445678901234456789012344567890123445678
+INFO - Using profile: development
+INFO - Success! Your credentials will expire in 3600 seconds at: 2015-12-21 23:09:04+00:00
 ```

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ Usage
                         Friendly session name required when using --assume-
                         role. By default, this is your local username.
 --qrcode QRCODE         If using QRCODE secret as an argument, calculates
-                        totp internally.
+                        totp internally. This value can also be provided
+                        via the environment variable 'MFA_QRCODE' or the
+                        ~/.aws/credentials variable 'aws_mfa_qrcode'.
                      
 ```
 
@@ -203,6 +205,17 @@ INFO - Success! Your credentials will expire in 1800 seconds at: 2015-12-21 23:0
 
 ```sh
 export MFA_DEVICE=arn:aws:iam::123456788990:mfa/dudeman
+export MFA_STS_DURATION=1800
+$> aws-mfa
+INFO - Using profile: default
+INFO - Your credentials have expired, renewing.
+Enter AWS MFA code for device [arn:aws:iam::123456788990:mfa/dudeman] (renewing for 1800 seconds):123456
+INFO - Success! Your credentials will expire in 1800 seconds at: 2015-12-21 23:07:09+00:00
+```
+
+```sh
+export MFA_DEVICE=arn:aws:iam::123456788990:mfa/dudeman
+export MFA_QRCODE=1234567890123456789012345678901234567890123456789012345678901234
 export MFA_STS_DURATION=1800
 $> aws-mfa
 INFO - Using profile: default
@@ -295,5 +308,17 @@ Using qrcode secret as an argument, so calculates qrcode internally
 ```sh
 $> aws-mfa --device arn:aws:iam::123456788990:mfa/dudeman --profile development --qrcode 1234456789012344567890123445678901234456789012344567890123445678
 INFO - Using profile: development
-INFO - Success! Your credentials will expire in 3600 seconds at: 2015-12-21 23:09:04+00:00
+INFO - Success! Your credentials will expire in 3600 seconds at: 2023-05-04 23:09:04+00:00
 ```
+
+Using qrcode secret as saved parameter in credentials file
+
+```sh
+export MFA_DEVICE=arn:aws:iam::123456788990:mfa/dudeman
+export MFA_QRCODE=1234567890123456789012345678901234567890123456789012345678901234
+export MFA_STS_DURATION=1800
+$> aws-mfa --profile development
+INFO - Using profile: development
+INFO - Success! Your credentials will expire in 3600 seconds at: 2023-05-04 23:09:04+00:00
+```
+

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -89,7 +89,10 @@ def main():
     # qr code as optional argument
     parser.add_argument('--qrcode',
                         type=str,
-                        help="Provide QR Code secret as an argument",
+                        help="QR Code secret - obtained when assigning MFA."
+                        "This value can also be provided via the"
+                        " environment variable 'MFA_QRCODE' or the"
+                        " ~/.aws/credentials variable 'aws_mfa_qrcode'.",
                         required=False)
     args = parser.parse_args()
 
@@ -186,6 +189,13 @@ def validate(args, config):
                                'You must provide --device or MFA_DEVICE or set '
                                '"aws_mfa_device" in ".aws/credentials"')
 
+    # get qrcode secret from param, env var or config
+    if not args.qrcode:
+        if os.environ.get('MFA_QRCODE'):
+            args.qrcode = os.environ.get('MFA_QRCODE')
+        elif config.has_option(long_term_name, 'aws_mfa_qrcode'):
+            args.qrcode = config.get(long_term_name, 'aws_mfa_qrcode')
+            
     # get assume_role from param or env var
     if not args.assume_role:
         if os.environ.get('MFA_ASSUME_ROLE'):

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -299,9 +299,9 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
     # qr code as argument
     if args.qrcode:
         logger.debug("Received qrcode as argument")
-         mfa_secretqr = '%s' % (args.qrcode)
-         mfa_token_code = pyotp.TOTP(mfa_secretqr)
-         mfa_token = str(mfa_token_code.now())
+        mfa_secretqr = '%s' % (args.qrcode)
+        mfa_token_code = pyotp.TOTP(mfa_secretqr)
+        mfa_token = str(mfa_token_code.now())
     else:
         if args.token:
             logger.debug("Received token as argument")

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,8 @@ setup(
         ],
     },
     url='https://github.com/broamski/aws-mfa',
-    install_requires=['boto3']
+    install_requires=[
+        'boto3',
+        'pyotp'
+    ]
 )


### PR DESCRIPTION
Adding QRCODE Secret - obtained when assigning MFA device - as either an _argument_, _credential_ config or _environment variable_, and using that secret to calculate Time-based One Time Password, **eliminating** the need of having to type token every time.