### PR TITLE
Remove scripts from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     author='Brian Nuszkowski',
     author_email='brian@bnuz.co',
     packages=['awsmfa'],
-    scripts=['aws-mfa'],
     entry_points={
         'console_scripts': [
             'aws-mfa=awsmfa:main',


### PR DESCRIPTION
This isn't needed since a console script entry point is defined. Unlike pip, when installing using [PyPA installer](https://installer.pypa.io/en/stable/), an error is thrown when it encounters the duplicate script.