### PR TITLE
Add Region Support for GovCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ aws_secret_access_key = <POPULATED_BY_AWS-MFA>
 aws_security_token = <POPULATED_BY_AWS-MFA>
 ```
 
+Regions and GovCloud
+--------------------
+
+Normally any commercial end-point can be used, but in many regions and in particular in GovCloud you
+need to use a specific region (or regions). By default you aws configure region is used. If you need
+to override this then you can use either the `--region us-gov-west-1` CLI option or you can add a region
+specification to your long-term credentials.
+
+```[govcloud-long-term]
+aws_access_key_id = YOUR_LONGTERM_KEY_ID
+aws_secret_access_key = YOUR_LONGTERM_ACCESS_KEY
+region = us-gov-west-1
+```
+
 Usage
 -----
 
@@ -153,7 +167,7 @@ Usage
                         To identify the long term credential section by
                         [<profile_name>-LONG_TERM_SUFFIX]. Use 'none' to
                         identify the long term credential section by
-                        [<profile_name>]. Omit to identify the long term 
+                        [<profile_name>]. Omit to identify the long term
                         credential section by [<profile_name>-long-term].
 --short-term-suffix SHORT_TERM_SUFFIX
                         To identify the short term credential section by
@@ -167,6 +181,11 @@ Usage
 --role-session-name ROLE_SESSION_NAME
                         Friendly session name required when using --assume-
                         role. By default, this is your local username.
+--force                 Refresh credentials even if currently valid.
+--region REGION         Optional specify the region to connect to.
+--log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG,NOTSET}
+                        Set log level
+--setup                 Setup a new log term credentials section
 ```
 
 **Argument precedence**: Command line arguments take precedence over environment variables.
@@ -277,7 +296,7 @@ INFO - Your credentials have expired, renewing.
 Enter AWS MFA code for device [arn:aws:iam::111111111111:mfa/me] (renewing for 3600 seconds):123456
 INFO - Success! Your credentials will expire in 3600 seconds at: 2017-07-10 07:16:43+00:00
 
-$> aws-mfa —profile myorganization --assume-role arn:aws:iam::333333333333:role/Administrator --short-term-suffix staging --long-term-suffix none --role-session-name staging 
+$> aws-mfa —profile myorganization --assume-role arn:aws:iam::333333333333:role/Administrator --short-term-suffix staging --long-term-suffix none --role-session-name staging
 INFO - Validating credentials for profile: myorganization-staging with assumed role arn:aws:iam::333333333333:role/Administrator
 INFO - Your credentials have expired, renewing.
 Enter AWS MFA code for device [arn:aws:iam::111111111111:mfa/me] (renewing for 3600 seconds):123456

--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -194,8 +194,8 @@ def validate(args, config):
 
     # get region to use form args or credentials file
     if not args.region:
-      if config.has_option(long_term_name, 'region'):
-        args.region = config.get(long_term_name, 'region')
+        if config.has_option(long_term_name, 'region'):
+            args.region = config.get(long_term_name, 'region')
 
     # If this is False, only refresh credentials if expired. Otherwise
     # always refresh.
@@ -287,13 +287,13 @@ def get_credentials(short_term_name, lt_key_id, lt_access_key, args, config):
                               '(renewing for %s seconds):' %
                               (args.device, args.duration))
 
-    config=None if args.region is None else Config(region_name = args.region)
+    aws_config=None if args.region is None else Config(region_name = args.region)
 
     client = boto3.client(
         'sts',
         aws_access_key_id=lt_key_id,
         aws_secret_access_key=lt_access_key,
-        config=config
+        config=aws_config
     )
 
     if args.assume_role:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-mfa',
-    version='0.0.12',
+    version='0.0.13',
     description='Manage AWS MFA Security Credentials',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Seems like I'm the 10th person to add region support so here is another fork that does it, both on the command line and in the credential file.

If you need it: 

```
 pip3 install git+https://github.com/Issio-Contribute/aws-mfa
```

Updated readme at:  https://github.com/Issio-Contribute/aws-mfa?tab=readme-ov-file#regions-and-govcloud